### PR TITLE
Add HappyPlaceRepository tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     ksp("com.google.dagger:hilt-android-compiler:2.48")
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/test/java/com/happyplaces/database/HappyPlaceRepositoryTest.kt
+++ b/app/src/test/java/com/happyplaces/database/HappyPlaceRepositoryTest.kt
@@ -1,0 +1,71 @@
+package com.happyplaces.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HappyPlaceRepositoryTest {
+
+    private lateinit var database: UserDatabase
+    private lateinit var dao: UserDao
+    private lateinit var repository: HappyPlaceRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, UserDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.dao
+        repository = HappyPlaceRepository(dao)
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun insert_happy_place() = runBlocking {
+        val place = HappyPlace(0, "Title", null, "Desc", "Date", "Location", 0.0, 0.0)
+        val id = repository.insert(place)
+
+        val list = repository.dataList.first()
+        assertEquals(1, list.size)
+        assertEquals(id.toInt(), list[0].id)
+    }
+
+    @Test
+    fun update_happy_place() = runBlocking {
+        val place = HappyPlace(0, "Title", null, "Desc", "Date", "Location", 0.0, 0.0)
+        val id = repository.insert(place)
+        val inserted = repository.dataList.first()[0]
+        val updated = inserted.copy(title = "Updated")
+
+        repository.update(updated)
+
+        val list = repository.dataList.first()
+        assertEquals(1, list.size)
+        assertEquals("Updated", list[0].title)
+    }
+
+    @Test
+    fun delete_happy_place() = runBlocking {
+        val place = HappyPlace(0, "Title", null, "Desc", "Date", "Location", 0.0, 0.0)
+        repository.insert(place)
+        val inserted = repository.dataList.first()[0]
+
+        repository.delete(inserted)
+
+        val list = repository.dataList.first()
+        assertTrue(list.isEmpty())
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for HappyPlaceRepository using Room in-memory database
- add androidx.test:core dependency for `ApplicationProvider`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840db4a0d308325bb39e0fc4ecbadcf